### PR TITLE
Improve route not found reporting

### DIFF
--- a/static/app/views/app/index.tsx
+++ b/static/app/views/app/index.tsx
@@ -34,6 +34,7 @@ import type {InstallWizardProps} from 'sentry/views/admin/installWizard';
 import {AsyncSDKIntegrationContextProvider} from 'sentry/views/app/asyncSDKIntegrationProvider';
 import {OrganizationContextProvider} from 'sentry/views/organizationContext';
 import RouteAnalyticsContextProvider from 'sentry/views/routeAnalyticsContextProvider';
+import {LastKnownRouteContextProvider} from 'sentry/views/lastKnownRouteContext';
 
 import SystemAlerts from './systemAlerts';
 
@@ -241,22 +242,24 @@ function App({children, params}: Props) {
 
   return (
     <Profiler id="App" onRender={onRenderCallback}>
-      <RouteAnalyticsContextProvider>
-        <OrganizationContextProvider>
-          <AsyncSDKIntegrationContextProvider>
-            <GlobalDrawer>
-              <GlobalFeedbackForm>
-                <MainContainer tabIndex={-1} ref={mainContainerRef}>
-                  <GlobalModal onClose={handleModalClose} />
-                  <SystemAlerts className="messages-container" />
-                  <Indicators className="indicators-container" />
-                  <ErrorBoundary>{renderBody()}</ErrorBoundary>
-                </MainContainer>
-              </GlobalFeedbackForm>
-            </GlobalDrawer>
-          </AsyncSDKIntegrationContextProvider>
-        </OrganizationContextProvider>
-      </RouteAnalyticsContextProvider>
+      <LastKnownRouteContextProvider>
+        <RouteAnalyticsContextProvider>
+          <OrganizationContextProvider>
+            <AsyncSDKIntegrationContextProvider>
+              <GlobalDrawer>
+                <GlobalFeedbackForm>
+                  <MainContainer tabIndex={-1} ref={mainContainerRef}>
+                    <GlobalModal onClose={handleModalClose} />
+                    <SystemAlerts className="messages-container" />
+                    <Indicators className="indicators-container" />
+                    <ErrorBoundary>{renderBody()}</ErrorBoundary>
+                  </MainContainer>
+                </GlobalFeedbackForm>
+              </GlobalDrawer>
+            </AsyncSDKIntegrationContextProvider>
+          </OrganizationContextProvider>
+        </RouteAnalyticsContextProvider>
+      </LastKnownRouteContextProvider>
     </Profiler>
   );
 }

--- a/static/app/views/lastKnownRouteContext.tsx
+++ b/static/app/views/lastKnownRouteContext.tsx
@@ -1,0 +1,30 @@
+import {createContext, useContext, useEffect, useRef, useState} from 'react';
+
+import {useLocation} from 'sentry/utils/useLocation';
+
+const LastKnownRouteContext = createContext<string>('');
+
+export function LastKnownRouteContextProvider({children}: {children?: React.ReactNode}) {
+  const location = useLocation();
+  const previousPathRef = useRef(location.pathname);
+  const [lastKnownRoute, setLastKnownRoute] = useState(location.pathname);
+
+  useEffect(() => {
+    if (location.pathname !== previousPathRef.current) {
+      setLastKnownRoute(previousPathRef.current);
+      previousPathRef.current = location.pathname;
+    }
+  }, [location.pathname]);
+
+  return (
+    <LastKnownRouteContext.Provider value={lastKnownRoute}>
+      {children}
+    </LastKnownRouteContext.Provider>
+  );
+}
+
+export function useLastKnownRoute() {
+  return useContext(LastKnownRouteContext);
+}
+
+export default LastKnownRouteContext;

--- a/static/app/views/routeNotFound.tsx
+++ b/static/app/views/routeNotFound.tsx
@@ -8,11 +8,13 @@ import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import Sidebar from 'sentry/components/sidebar';
 import {t} from 'sentry/locale';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
+import {useLastKnownRoute} from 'sentry/views/lastKnownRouteContext';
 
 type Props = RouteComponentProps<{}, {}>;
 
 function RouteNotFound({router, location}: Props) {
   const {pathname, search, hash} = location;
+  const lastKnownRoute = useLastKnownRoute();
 
   const isMissingSlash = pathname[pathname.length - 1] !== '/';
 
@@ -24,16 +26,17 @@ function RouteNotFound({router, location}: Props) {
     }
 
     Sentry.withScope(scope => {
-      scope.setFingerprint(['RouteNotFound']);
+      scope.setFingerprint(['RouteNotFound', lastKnownRoute]);
       scope.setTag('isMissingSlash', isMissingSlash);
       scope.setTag('pathname', pathname);
+      scope.setTag('lastKnownRoute', lastKnownRoute);
       scope.setTag(
         'reactRouterVersion',
         window.__SENTRY_USING_REACT_ROUTER_SIX ? '6' : '3'
       );
       Sentry.captureException(new Error('Route not found'));
     });
-  }, [pathname, search, hash, isMissingSlash, router]);
+  }, [pathname, search, hash, isMissingSlash, router, lastKnownRoute]);
 
   if (isMissingSlash) {
     return null;


### PR DESCRIPTION
## Summary
- track the last valid route
- tag RouteNotFound errors with the last route
- wrap the app with a provider for last-known route

## Testing
- `yarn lint:js static/app/views/app/index.tsx` *(fails: This package doesn't seem to be present in your lockfile)*